### PR TITLE
Fix the xode_version fact

### DIFF
--- a/lib/facter/xcode_version.rb
+++ b/lib/facter/xcode_version.rb
@@ -5,12 +5,12 @@
 # Antti Pettinen
 # Copyright: Tampere University of Technology
 require 'facter'
-require 'CFPropertyList'
 Facter.add(:xcode_version) do
   confine :kernel => 'Darwin'
   setcode do
     if File.exists? '/Applications/Xcode/Contents/Info.plist'
       # Facter::Core::Execution.exec('/usr/bin/defaults read '/Applications/Xcode.app/Contents/Info' CFBundleShortVersionString')
+      require 'CFPropertyList'
       CFPropertyList.native_types(CFPropertyList::List.new(:file => "/Applications/Xcode.app/Contents/Info.plist").value)['CFBundleShortVersionString']
     end
   end

--- a/lib/facter/xcode_version.rb
+++ b/lib/facter/xcode_version.rb
@@ -8,7 +8,7 @@ require 'facter'
 Facter.add(:xcode_version) do
   confine :kernel => 'Darwin'
   setcode do
-    if File.exists? '/Applications/Xcode/Contents/Info.plist'
+    if File.exists? '/Applications/Xcode.app/Contents/Info.plist'
       # Facter::Core::Execution.exec('/usr/bin/defaults read '/Applications/Xcode.app/Contents/Info' CFBundleShortVersionString')
       require 'CFPropertyList'
       CFPropertyList.native_types(CFPropertyList::List.new(:file => "/Applications/Xcode.app/Contents/Info.plist").value)['CFBundleShortVersionString']


### PR DESCRIPTION
The `xcode_version` fact has two issues:
* it loads `CFPropertyList` even on non `Darwin` machines which generates an error if you happen to have a puppet master that also serves manifests to non mac machines
* it checks for an inexistant file before getting the xcode version
